### PR TITLE
Compatibility issues with mysqldump >=5.6

### DIFF
--- a/src/McCool/DatabaseBackup/Dumpers/MysqlDumper.php
+++ b/src/McCool/DatabaseBackup/Dumpers/MysqlDumper.php
@@ -106,7 +106,7 @@ class MysqlDumper implements DumperInterface
     {
         $this->processor->process($this->getCommand());
 
-        if ($this->processor->getErrors()) {
+        if ($this->processor->getErrors() && ( ! ($this->processor->getErrors() != "Warning: Using a password on the command line interface can be insecure\n."))) {
             throw new ProcessorException($this->processor->getErrors());
         }
     }


### PR DESCRIPTION
Hi Shawn,

There is a compatibility issue with this library and mysqldump >=5.6

The "issue" is with mysqldump after version 5.6 where it will output a "warning" message every time you use it and include a password in the command line (which your package does). You can read about the issue extensively here:

http://bugs.mysql.com/bug.php?id=66546

and more here 

http://serverfault.com/questions/476228/whats-a-secure-alternative-to-using-a-mysql-password-on-the-command-line

Whilst the work around is to put the username/password in a specific file, that is not possible for everyone, myself included.

The problem with your package is your process() command in Mysqldumper.php throws an exception, and wont proceed (because mysqldump gave a 'warning' message). By modifying your process() command to ignore that one specific warning, I am able to use your package without issue.

Its a little messy, but I dont see any other way around the problem. Perhaps this could be a configurable item in your package config, so people can optionally ignore this one specific error?
